### PR TITLE
enable passing id to inner form for enabling html5 button form attribute

### DIFF
--- a/definitions/common.ts
+++ b/definitions/common.ts
@@ -80,6 +80,7 @@ export type ValidationProps = {
 };
 
 export type CommonLetsFormProps = {
+  id?: string;
   name?: string;
   locale?: Locale;
   plaintext?: boolean;

--- a/react-mantine/form/index.js
+++ b/react-mantine/form/index.js
@@ -7,6 +7,7 @@ import './form.scss';
 import { lfLog } from '../../helpers/lf-log';
 
 const MantineForm = ({
+  id,
   name,
   children,
   buttonsAlign,
@@ -24,6 +25,7 @@ const MantineForm = ({
   return (
     <div>
       <form
+        id={id}
         onSubmit={onSubmit}
         className={classNames('lf-form lf-form-react-mantine', {
           [buttonsAlign ? `lf-form-buttons-align-${buttonsAlign}` : undefined]: true

--- a/react-material-ui/form/index.js
+++ b/react-material-ui/form/index.js
@@ -6,6 +6,7 @@ import classNames from 'classnames';
 import { lfLog } from '../../helpers/lf-log';
 
 const FormMaterialUI = ({
+  id,
   name,
   buttonsAlign,
   children,
@@ -23,6 +24,7 @@ const FormMaterialUI = ({
 
   return (
     <form
+      id={id}
       className={classNames('lf-form lf-form-react-material-ui', {
         'lf-form-react-material-ui-plaintext': plaintext,
         [buttonsAlign ? `lf-form-buttons-align-${buttonsAlign}` : undefined]: true

--- a/react/form/index.js
+++ b/react/form/index.js
@@ -6,6 +6,7 @@ import { lfLog } from '../../helpers/lf-log';
 import './index.scss';
 
 const FormReact = ({
+  id,
   name,
   children,
   buttonsAlign,
@@ -23,6 +24,7 @@ const FormReact = ({
 
   return (
     <form
+      id={id}
       onSubmit={onSubmit}
       className={classNames('lf-form lf-form-react lf-form-react-stacked', {
         [buttonsAlign ? `lf-form-buttons-align-${buttonsAlign}` : undefined]: true


### PR DESCRIPTION
Allows for decoupling the submit button from the `<LetsForm />` component

```tsx
<button type="submit" form="my-form">Trigger onSubmit</button>
...
<LetsForm id="my-form" />
```

see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#form