### PR TITLE
add className for divider and columns

### DIFF
--- a/common/columns/index.js
+++ b/common/columns/index.js
@@ -8,11 +8,12 @@ import './columns.scss';
 
 const Columns = ({
   name,
+  className,
   children,
   columns
 }) => {
   return (
-    <div {...makeClassName('columns', name)}>
+    <div {...makeClassName('columns', name, className)}>
       {(columns || [])
         .filter(column => column.hidden !== true)
         .map(column => (

--- a/common/divider/index.js
+++ b/common/divider/index.js
@@ -8,10 +8,11 @@ import { makeClassName } from '../../helpers/make-class-name';
 const Divider = ({
   name,
   size,
+  className,
   color
 }) => {
   return (
-    <div {...makeClassName('divider', name)}>
+    <div {...makeClassName('divider', name, className)}>
       <div
         className="bar"
         style={{


### PR DESCRIPTION
Hi, I tried adding the classname for columns and divider using 0.12.7 but found it not working, and not sure if the columns and divider are missing the `className` props and should add the `className` this way
Thanks.